### PR TITLE
Add support for %%-style comments

### DIFF
--- a/examples/standalone.md
+++ b/examples/standalone.md
@@ -15,6 +15,14 @@ word_goal: 2000
 type: story
 ---
 
+%%
+This is a Markdown block content. None of it should be visible in the compiled manuscript.
+%%
+
+%% This is a single comment %%
+
+<!-- This is an HTML comment block -->
+
 [Lorem ipsum](https://www.lipsum.com/) ~~dolor~~ **sit** _amet_, "consectetur adipiscing" elit. Ut ut ullamcorper eros, vel auctor sapien. Suspendisse potenti. Nullam laoreet sem ut ipsum convallis, dictum vestibulum arcu tempus. Nulla in fermentum magna. Cras viverra turpis felis, non molestie justo fermentum quis. Donec magna arcu, tempor sit amet venenatis non, bibendum dignissim ligula. Duis maximus vel erat nec eleifend. In id iaculis lorem. Cras eu ipsum aliquet, bibendum mi id, dignissim diam. Mauris pretium elit at rhoncus lobortis. Donec ac rhoncus purus, a tristique mauris. Aenean sollicitudin ligula libero, vel ornare lectus euismod sed. Nulla porta justo a purus congue consequat. Cras eu lorem vehicula, bibendum neque vitae, posuere nunc.
 
 Nulla efficitur, nisi in laoreet consequat, elit nisi dignissim tortor, sed tincidunt lectus tellus interdum massa. Maecenas in laoreet urna. Proin enim arcu, aliquet ut volutpat dapibus, vehicula quis odio. Pellentesque faucibus nisl quis bibendum pretium. Curabitur sit amet pharetra dolor. Nullam quis erat at neque fringilla finibus. Sed viverra et ex vitae egestas. Vivamus non dapibus sem.

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -11,7 +11,14 @@ use yaml_front_matter::{Document, YamlFrontMatter};
 
 
 /// Convert the content of a Markdown into a collection of paragraphs.
-fn content_to_paragraphs(content: String) -> Vec<Paragraph> {
+fn content_to_paragraphs(mut content: String) -> Vec<Paragraph> {
+
+    // Pre-process the content
+
+    // Add support single and multi-line %% comment blocks %%
+    let re = Regex::new(r"%%\s+.*?\s+%%").unwrap();
+    content = Regex::replace_all(&re, content.as_str(), "").to_string();
+
     let mut paragraphs: Vec<Paragraph> = vec![];
     let sep = Paragraph::new()
         .add_run(Run::new().add_text("#"))


### PR DESCRIPTION
Adds support for single and multi-line %% comment blocks %%, matching the functionality of Obsidian.

This fixes #7 